### PR TITLE
Check validity of Account Number in Account Constructor

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -19,6 +19,9 @@ export class Account {
     let accountKeys: AccountKeys;
     if (accountNumber && signingKey) {
       accountKeys = Account.fromBothKeys(signingKey, accountNumber);
+      if (accountKeys[0].toString() !== Account.fromSigningKey(signingKey)[0].toString()) {
+        console.log("invalid Account Number!"); // Did a console.log here not to break anything. Maybe throw an error.
+      }
     } else if (signingKey) {
       accountKeys = Account.fromSigningKey(signingKey);
     } else {


### PR DESCRIPTION
When we instantiate a new Account object, we can choose to supply the accountNumber and signingKey. I added a check to validate the accountNumber and signingKey, to see if they match. Please replace the `console.log` with something else.