### PR TITLE
Fix: Replaced startCrawl and stopCrawl return types

### DIFF
--- a/src/bank.ts
+++ b/src/bank.ts
@@ -12,11 +12,11 @@ import type {
   PaginatedBlockEntry,
   PaginatedValidatorEntry,
   CleanResponse,
+  CrawlResponse,
   CleanData,
   CrawlData,
 } from "./models";
 import type { Account } from "./account";
-import { CrawlResponse } from "./models/responses/generic/crawl";
 
 /** Used for creating banks and sending requests easily to that specific bank server node. */
 export class Bank extends ServerNode {
@@ -119,7 +119,7 @@ export class Bank extends ServerNode {
    * @param account An Account created with the Network Id Signing key of the current Bank
    */
   async startCrawl(account: Account) {
-    return await super.postData<CleanResponse>(
+    return await super.postData<CrawlResponse>(
       "/crawl",
       account.createSignedMessage<CrawlData>({ crawl: "start" })
     );
@@ -130,7 +130,7 @@ export class Bank extends ServerNode {
    * @param account An Account created with the Network Id Signing key of the current Bank
    */
   async stopCrawl(account: Account) {
-    return await super.postData<CleanResponse>(
+    return await super.postData<CrawlResponse>(
       "/crawl",
       account.createSignedMessage<CrawlData>({ crawl: "stop" })
     );

--- a/src/confirmation-validator.ts
+++ b/src/confirmation-validator.ts
@@ -1,6 +1,6 @@
 import { Validator } from "./validator";
 import type { Account } from "./account";
-import type { ConfirmationValidatorConfigResponse, CrawlData, CrawlCommand, CleanResponse, CleanData } from "./models";
+import type { ConfirmationValidatorConfigResponse, CleanResponse, CrawlResponse, CleanData, CrawlData } from "./models";
 
 /** Used for connecting with and using confirmation validator server nodes. */
 export class ConfirmationValidator extends Validator {
@@ -11,7 +11,7 @@ export class ConfirmationValidator extends Validator {
 
   /** Gets the current crawl status */
   async getCrawlStatus() {
-    return await super.getData("/crawl");
+    return await super.getData<CrawlResponse>("/crawl");
   }
 
   /**
@@ -19,9 +19,9 @@ export class ConfirmationValidator extends Validator {
    * @param account An Account created with the Network Id Signing key of the current Confirmation Validator
    */
   async startCrawl(account: Account) {
-    return await super.postData<CleanResponse>(
+    return await super.postData<CrawlResponse>(
       "/crawl",
-      account.createSignedMessage<CleanData>({ clean: "start" })
+      account.createSignedMessage<CrawlData>({ crawl: "start" })
     );
   }
 
@@ -30,9 +30,9 @@ export class ConfirmationValidator extends Validator {
    * @param account An Account created with the Network Id Signing key of the current Confirmation Validator
    */
   async stopCrawl(account: Account) {
-    return await super.postData<CleanResponse>(
+    return await super.postData<CrawlResponse>(
       "/crawl",
-      account.createSignedMessage<CleanData>({ clean: "stop" })
+      account.createSignedMessage<CrawlData>({ crawl: "stop" })
     );
   }
 

--- a/src/confirmation-validator.ts
+++ b/src/confirmation-validator.ts
@@ -72,7 +72,7 @@ export class ConfirmationValidator extends Validator {
    * @param protocol the protocol of the primary validator
    * @param account the account that the current `ConfirmationValidator` is connected to
    */
-  async sendPrimaryValidatorUpdatedPing(ipAddress: string, port: string, protocol: string, account: Account) {
+  async sendPrimaryValidatorUpdatedPing(ipAddress: string, port: number, protocol: string, account: Account) {
     return await super.postData(
       "/primary_validator_updated",
       account.createSignedMessage({ ip_address: ipAddress, port, protocol })

--- a/src/models/responses/generic/index.ts
+++ b/src/models/responses/generic/index.ts
@@ -1,3 +1,4 @@
 export type { AccountBalanceLockResponse } from "./account-balance-lock";
 export type { AccountBalanceResponse } from "./account-balance";
 export type { CleanResponse } from "./clean";
+export type { CrawlResponse } from "./crawl";

--- a/src/models/responses/pagination/entries/bank.ts
+++ b/src/models/responses/pagination/entries/bank.ts
@@ -1,10 +1,10 @@
-import type { Protocol, Version } from "../../constants";
+import type { Port, Protocol, Version } from "../../constants";
 
 export interface PaginatedBankEntry {
   account_number: string;
   ip_address: string;
   node_identifier: string;
-  port: number | null;
+  port: Port | null;
   protocol: Protocol;
   version: Version;
   default_transaction_fee: number;

--- a/src/models/responses/pagination/entries/validator.ts
+++ b/src/models/responses/pagination/entries/validator.ts
@@ -1,16 +1,16 @@
-import type { Protocol, Version } from "../../constants";
+import type { Port, Protocol, Version } from "../../constants";
 
 export interface PaginatedValidatorEntry {
   account_number: string;
   ip_address: string;
   node_identifier: string;
-  port: string | null;
+  port: Port | null;
   protocol: Protocol;
   version: Version;
   default_transaction_fee: number;
   root_account_file: string;
   root_account_file_hash: string;
   seed_block_identifier: string;
-  daily_confirmation_rate: number | null;
+  daily_confirmation_rate: Port | null;
   trust: string;
 }

--- a/src/server-node.ts
+++ b/src/server-node.ts
@@ -10,7 +10,6 @@ import type {
 import type { Account } from "./account";
 import type { Protocol } from "./models/responses/constants";
 import { throwError } from "./utils";
-import { CrawlResponse } from "./models/responses/generic/crawl";
 
 /**
  * Used internally for all server nodes.
@@ -95,7 +94,7 @@ export abstract class ServerNode {
    * @param protocol the new node's protocol
    * @param account the server account to validate the request
    */
-  async sendConnectionRequest(ipAddress: string, port: string, protocol: Protocol, account: Account) {
+  async sendConnectionRequest(ipAddress: string, port: number, protocol: Protocol, account: Account) {
     return await this.postData(
       "/connection_requests",
       account.createSignedMessage({


### PR DESCRIPTION
I made a mistake in the crawl methods for both the bank and validator class. 
The crawl response was set to type `CleanResponse` instead of `Crawlresponse`.
I have replaced them with this PR.

Pls @zinoadidi  when you have time update the npm package.