### PR TITLE
fix: `Account.isValidPair` throwing on invalid seeds

### DIFF
--- a/src/account.ts
+++ b/src/account.ts
@@ -52,7 +52,11 @@ export class Account {
    * @param accountNumber the given account number hex string
    */
   static isValidPair(signingKey: string, accountNumber: string) {
-    return new Account(signingKey).accountNumberHex === accountNumber;
+    try {
+      return new Account(signingKey).accountNumberHex === accountNumber;
+    } catch (_) {
+      return false;
+    }
   }
 
   /** The 32 byte account number as a 32 byte hex string. */

--- a/tests/account.test.js
+++ b/tests/account.test.js
@@ -46,6 +46,15 @@ describe("Account", () => {
     expect(Account.isValidPair(defaultAccount.accountNumber, defaultAccount.signingKey)).toBeFalsy();
   });
 
+  it("isValidPair doesn't throw errors", () => {
+    const results = [
+      Account.isValidPair("asdf", "asdf"),
+      Account.isValidPair(defaultAccount.signingKey, "asdf"),
+      Account.isValidPair("asdf", defaultAccount.accountNumber),
+    ];
+    expect(results.every((val) => typeof val === "boolean")).toBeTruthy();
+  });
+
   it("createSignature(message)", () => {
     const account = createDefaultAccount();
     assertAccountBasics(account);


### PR DESCRIPTION
# Description

The issue was that `Account.isValidPair` was throwing errors when the seed inputs were not of valid lengths or were not actual hex characters.  This PR fixes that issue and implements tests to ensure this behavior stays fixed.

Fixes #151 

## Type of change

- [ ] Chore (chore: description-of-task)
- [x] Fix (fix: description-of-fix)
- [ ] Feature (feat: description-of-fix)
- [ ] Test (test: description-of-tests-performed)
- [ ] Docs (docs: description-of-docs-added-or-modified)
- [ ] Refactor (refactor: description-of-refactor)

Please specify the type of change in your title following the above format


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules